### PR TITLE
Update Rails_Shopping_Cart.md

### DIFF
--- a/Rails_Shopping_Cart.md
+++ b/Rails_Shopping_Cart.md
@@ -27,7 +27,7 @@ Build a minimum of four models (excluding User authentication for now):
   - Join Table which bridges Product and Cart. Needed to add multiple quantities of each product to Cart (see below)
     - belongs_to :product
     - belongs_to :cart
-    - belongs_to :order (for checkout see below)  
+    - belongs_to :order, optional: true (for checkout see below)  
 
 
 3. **Cart**:


### PR DESCRIPTION
Correct `line_item` `belongs_to :order` association to permit saving without having an order created (will be created before checkout): 
- before: `belongs_to :order`
- now: `belongs_to :order, optional: true`